### PR TITLE
Make pgod have more defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ A typical config file looks like this:
 name = "pgo"
 user = "miek"
 repository = "https://github.com/miekg/pgo"
-compose = "compose.yaml" # alternate, non-default compose file.
-branch = "main" # defaults to main, is omitted.
-ignore = false # when true don't restart podman-compose when it changes
+compose = "compose.yaml"
+branch = "main"
+ignore = false
 urls = { "pgo.science.ru.nl" = "5007" }
 ports = [ "5005/5", "1025/5" ]
 ```
@@ -47,7 +47,9 @@ To go over this file:
 
 - `name`: this is the name of the service, used to uniquely identify the service across machines.
 - `user`: which user to use to run the podman-compose under.
-- `repository` and `branch`: where to find the git repo belonging to this service
+- `repository` and `branch`: where to find the git repo belonging to this service.
+- `compose`: alternate compose file to use.
+- `ignore`: don't restart podman when a compose file changes.
 - `urls`: what DNS names need to be assigned to this server and to what port should they forward.
 - `ports`: which ports can this service bind to.
 

--- a/cmd/pgoctl/pgoctl.1
+++ b/cmd/pgoctl/pgoctl.1
@@ -12,7 +12,9 @@ pgoctl - interact remotely with pgod(8)
 
 .SH "DESCRIPTION"
 .PP
-pgoctl is an utility to inspect and control pgod(8) remotely.
+pgoctl is an utility to inspect and control pgod(8) remotely. The exit status from the
+podman-compose is reflected in the exist status of pgoctl. Almost all commands from podman-compose
+are implemented.
 
 .PP
 There are only a few options:
@@ -59,7 +61,7 @@ Then up the services, if not done already:
 .RS
 
 .nf
-% cmd/pgoctl/pgoctl \-i ssh/id\_pgo4 localhost:pgo//up
+% cmd/pgoctl/pgoctl \-i ssh/id\_pgo localhost:pgo//up
 61380c3c0cbe9827f335b5d6e7690d3a366317f755d87f969fcd9b1cb4b2254c
 ['podman', '\-\-version', '']
 using podman version: 3.4.4
@@ -78,13 +80,32 @@ Looking at the \fB\fCps\fR:
 .RS
 
 .nf
-% cmd/pgoctl/pgoctl \-i ssh/id\_pgo4 localhost:pgo//ps
+% cmd/pgoctl/pgoctl \-i ssh/id\_pgo localhost:pgo//ps
 CONTAINER ID  IMAGE                             COMMAND               CREATED             STATUS                 PORTS                    NAMES
 61380c3c0cbe  docker.io/library/busybox:latest  /bin/busybox http...  About a minute ago  Up About a minute ago  0.0.0.0:36391\->8080/tcp  pgo\-3493677287\_frontend\_1
 ['podman', '\-\-version', '']
 using podman version: 3.4.4
 podman ps \-a \-\-filter label=io.podman.compose.project=pgo\-3493677287
 exit code: 0%
+
+.fi
+.RE
+
+.PP
+Or \fB\fCexec\fR inside a container/service. Podman-compose expect the service to be used here, this is the
+service \fIas specfied in the compose.yaml\fP.
+
+.PP
+.RS
+
+.nf
+% cmd/pgoctl/pgoctl \-i id\_pgo \-\- localhost:pgo//exec frontend /bin/ls
+bin    etc    lib    proc   run    tmp    var
+dev    home   lib64  root   sys    usr
+['podman', '\-\-version', '']
+using podman version: 3.4.4
+podman exec \-\-interactive \-\-tty \-\-env SECRET\_KEY2=aabbcc \-\-env ENV\_IS\_SET2=None pgo\_frontend\_1 /bin/ls
+exit code: 0
 
 .fi
 .RE

--- a/cmd/pgod/main.go
+++ b/cmd/pgod/main.go
@@ -32,9 +32,9 @@ func (exec *ExecContext) RegisterFlags(fs *flag.FlagSet) {
 		fs = flag.CommandLine
 	}
 	fs.SortFlags = false
-	fs.StringVarP(&exec.ConfigSource, "config", "c", "", "config file to read")
+	fs.StringVarP(&exec.ConfigSource, "config", "c", "/etc/pgo.toml", "config file to read")
 	fs.StringVarP(&exec.SAddr, "ssh", "s", ":2222", "ssh address to listen on")
-	fs.StringVarP(&exec.Dir, "dir", "d", "", "directory to check out the git repositories")
+	fs.StringVarP(&exec.Dir, "dir", "d", "/var/lib/pgo", "directory to check out the git repositories")
 	fs.BoolVarP(&exec.Debug, "debug", "", false, "enable debug logging")
 	fs.BoolVarP(&exec.Restart, "restart", "", false, "send SIGHUP when config changes")
 	fs.BoolVarP(&exec.Root, "root", "", true, "require root permission, setting to false can aid in debugging")

--- a/cmd/pgod/pgod.8
+++ b/cmd/pgod/pgod.8
@@ -38,7 +38,7 @@ backend.
 
 .PP
 For each repository it directs podman-compose to pull, build and start the containers defined in the
-\fB\fCdocker-compose.yml\fR file. Whenever this compose file changes this is redone. Current the following
+\fB\fCcompose.yaml\fR file. Whenever this compose file changes this is redone. Current the following
 compose file variants are supported: "compose.yaml", "compose.yml", "docker-compose.yml" and
 "docker-compose.yaml".
 
@@ -51,16 +51,18 @@ The options are:
 
 .TP
 \fB-c, --config string\fP
-config file to read
+config file to read, when not given this default to \fB\fC/etc/pgo.toml\fR
+.TP
+\fB-d, --dir string\fP
+directory where to check out the git repositories, this must be a directory that is not wiped
+when the system reboots; the directory must also be accessible for all user accounts defined
+in the configuration file; this default to \fB\fC/var/lib/pgo\fR.
 .TP
 \fB-s, --ssh string\fP
 ssh address to listen on (default ":2222")
 .TP
 \fB-t, --duration duration\fP
 default duration between pulls (default 5m0s)
-.TP
-\fB-d, --dir string\fP
-directory where to check out the git repositories
 .TP
 \fB--debug\fP
 enable debug logging
@@ -86,6 +88,8 @@ name = "pgo"
 user = "miek"
 repository = "https://github.com/miekg/pgo"
 branch = "main"
+ignore = false
+compose = "my\-compose.yaml"
 urls = { "example.org" = ":5006" }
 ports = [ "5005/5", "1025/5" ]
 
@@ -107,13 +111,19 @@ repository \fIand\fP branch
 \fB\fChttps://github.com/miekg/pgo\fR and \fB\fCmain\fR, where to clone and pull from. If branch is not
 specified \fB\fCmain\fR is assumed.
 .TP
+ignore
+\fB\fCfalse\fR, ignore changes to the compose yaml files and \fIdo not\fP restart containers.
+.TP
+compose
+\fB\fCmy-compose.yaml\fR, specify an alternate compose file to use, outside of the supported variants.
+.TP
 urls
 \fB\fC{ "example.org" = ":5006" }\fR how to setup any forwarding to the listening ports. This isn't used yet,
 but when the containers go up this should connect the url \fB\fCexample.org\fR to \fB\fC<thismachine>:5006\fR.
 .TP
 ports
 \fB\fC[ "5005/5", "1025/5" ]\fR, this service can bind to ports nummbers: 5005-5010 and 1025-1030. This
-is checked by parsing the \fB\fCdocker-compose-yml\fR.
+is checked by parsing the \fB\fCcompose.yaml\fR.
 
 
 .SH "AUTHENTICATION"

--- a/cmd/pgod/pgod.8.md
+++ b/cmd/pgod/pgod.8.md
@@ -48,7 +48,12 @@ With pgoctl(1) you can then interact with these services. You can "up", "down", 
 The options are:
 
 **-c, --config string**
-:  config file to read
+:  config file to read, when not given this default to `/etc/pgo.toml`
+
+**-d, --dir string**
+:  directory where to check out the git repositories, this must be a directory that is not wiped
+   when the system reboots; the directory must also be accessible for all user accounts defined
+   in the configuration file; this default to `/var/lib/pgo`.
 
 **-s, --ssh string**
 :  ssh address to listen on (default ":2222")
@@ -56,10 +61,6 @@ The options are:
 **-t, --duration duration**
 :  default duration between pulls (default 5m0s)
 
-**-d, --dir string**
-:  directory where to check out the git repositories, this must be a directory that is not wiped
-   when the system reboots; the directory must also be accessible for all user accounts defined
-   in the configuration file
 
 **--debug**
 :  enable debug logging


### PR DESCRIPTION
Just running `pgod` now works and uses default locations as /etc/pgo.toml and /var/lib/pgo for storage.

Update docs and manpages.