### PR TITLE
Remove docker-compose build

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Assuming a working Go compiler you can issue a `make` to compile the binaries. T
 Start `pgod`: `sudo /cmd/pgod/pgod -c pgo.toml -d /tmp/pgo --debug`. That will output some debug
 data.
 
-In other words: it clones the repo, builds, pulls, and starts the containers. It then *tracks*
+In other words: it clones the repo, pulls, and starts the containers. It then *tracks*
 upstream and whenever `compose.yaml` changes it will do a `down` and `up`. To force changes
 in that file you can use a `x-gpo-version` in the yaml and change that whenever you want to update
 "pgo"
@@ -147,7 +147,6 @@ deploy_production:
     on_stop: stop_production
   script:
     - pgoctl mymachine:project//pull  # looks for PGOCTL_ID env var, with privkey contents
-    - pgoctl mymachine:project//build
     - pgoctl mymachine:project//up
   when: manual
 

--- a/cmd/pgoctl/pgoctl.1
+++ b/cmd/pgoctl/pgoctl.1
@@ -4,7 +4,7 @@
 .SH "PGOCTL"
 .SH "NAME"
 .PP
-pgoctl - interact remotely with pgod(8)
+pgoctl \- interact remotely with pgod(8)
 
 .SH "SYNOPSIS"
 .PP
@@ -41,9 +41,9 @@ The supported commands are:
 .IP \(bu 4
 \fB\fClogs\fR run \fB\fCdocker-compose logs\fR
 .IP \(bu 4
-\fB\fCjournal\fRrun \fB\fCjournalctl _UID=<uid>\fR - show the system logs (if any)
+\fB\fCjournal\fRrun \fB\fCjournalctl _UID=<uid>\fR \- show the system logs (if any)
 .IP \(bu 4
-\fB\fCexec\fR run \fB\fCdocker-compose -T exec\fR - run any command in a container
+\fB\fCexec\fR run \fB\fCdocker-compose -T exec\fR \- run any command in a container
 .IP \(bu 4
 \fB\fCgit\fR \fBCOMMAND\fP
 where \fBCOMMAND\fP can be:
@@ -65,18 +65,18 @@ for example.
 There are only a few options:
 
 .TP
-\fB-i value\fP
+\fB\-i value\fP
 identity file to use for SSH, this flag is mandatory, but if an environment variable named
 "PGOCTL_ID" exists and has a value, that value will be used as the private key identity. If no
 such variable exist \fB\fC-i\fR \fIis\fP mandatory.
 .TP
-\fB--help, -h\fP
+\fB\-\-help, \-h\fP
 show help
 .TP
-\fB--port, -p port\fP
+\fB\-\-port, \-p port\fP
 remote port number to use (defaults to 2222)
 .TP
-\fB-v\fP
+\fB\-v\fP
 show version and exit
 
 
@@ -100,8 +100,6 @@ Start pgod(8) and look at some services:
 [INFO ] [pgo]: Checked out git repo in /tmp/pgo/pgo for "pgo" (branch main) with 3 configured public keys
 [INFO ] [caddy]: Pulling containers
 [INFO ] [pgo]: Pulling containers
-[INFO ] [caddy]: Building images
-[INFO ] [pgo]: Building images
 [INFO ] [caddy]: Upping services
 [INFO ] [pgo]: Upping services
 [INFO ] [caddy]: Tracking upstream

--- a/cmd/pgoctl/pgoctl.1.md
+++ b/cmd/pgoctl/pgoctl.1.md
@@ -77,8 +77,6 @@ Start pgod(8) and look at some services:
 [INFO ] [pgo]: Checked out git repo in /tmp/pgo/pgo for "pgo" (branch main) with 3 configured public keys
 [INFO ] [caddy]: Pulling containers
 [INFO ] [pgo]: Pulling containers
-[INFO ] [caddy]: Building images
-[INFO ] [pgo]: Building images
 [INFO ] [caddy]: Upping services
 [INFO ] [pgo]: Upping services
 [INFO ] [caddy]: Tracking upstream

--- a/cmd/pgod/pgod.8
+++ b/cmd/pgod/pgod.8
@@ -4,7 +4,7 @@
 .SH "PGOD"
 .SH "NAME"
 .PP
-pgod - watch a git repository, pull changes and restart the docker compose service
+pgod \- watch a git repository, pull changes and restart the docker compose service
 
 .SH "SYNOPSIS"
 .PP
@@ -15,7 +15,7 @@ pgod - watch a git repository, pull changes and restart the docker compose servi
 \fB\fCpgod\fR clones and pulls all repositories that are defined in the config file. It then starts all
 containers using the compose file in each repository. Further more it exposes an SSH interface (on
 port 2222) which you can interact with using pgoctl(1). Authentication is done via ssh public keys
-that are available in each repository. Each \fIcompose\fP runs under it's own user-account
+that are available in each repository. Each \fIcompose\fP runs under it's own user\-account
 
 .PP
 Servers running pgod(8) as still special in some regard, a developers needs to know which server
@@ -27,10 +27,10 @@ The interface into \fB\fCpgod\fR is via SSH, but not OpenSSH, this is a complete
 implemented by both \fB\fCpgod\fR and \fB\fCpgoctl\fR.
 
 .PP
-For each repository it directs docker compose to pull, build and start the containers defined in the
+For each repository it directs docker compose to pull and start the containers defined in the
 \fB\fCcompose.yaml\fR file. Whenever this compose file changes this is redone. Current the following
-compose file variants are supported: "compose.yaml", "compose.yml", "docker-compose.yml" and
-"docker-compose.yaml".
+compose file variants are supported: "compose.yaml", "compose.yml", "docker\-compose.yml" and
+"docker\-compose.yaml".
 
 .PP
 With pgoctl(1) you can then interact with these services. You can "up", "down", "ps", "pull",
@@ -44,27 +44,27 @@ confguration file.
 The options are:
 
 .TP
-\fB-c, --config string\fP
+\fB\-c, \-\-config string\fP
 config file to read, when not given this default to \fB\fC/etc/pgo.toml\fR
 .TP
-\fB-d, --dir string\fP
+\fB\-d, \-\-dir string\fP
 directory where to check out the git repositories, this must be a directory that is not wiped
 when the system reboots; the directory must also be accessible for all user accounts defined
 in the configuration file; this default to \fB\fC/var/lib/pgo\fR.
 .TP
-\fB-s, --ssh string\fP
+\fB\-s, \-\-ssh string\fP
 ssh address to listen on (default ":2222")
 .TP
-\fB-t, --duration duration\fP
+\fB\-t, \-\-duration duration\fP
 default duration between pulls (default 5m0s)
 .TP
-\fB--debug\fP
+\fB\-\-debug\fP
 enable debug logging
 .TP
-\fB--restart\fP
+\fB\-\-restart\fP
 send SIGHUP to ourselves when config changes (default true)
 .TP
-\fB-v\fP, \fB--version\fP
+\fB\-v\fP, \fB\-\-version\fP
 show version and exit
 
 
@@ -83,7 +83,6 @@ user = "miek"
 repository = "https://github.com/miekg/pgo"
 branch = "main"
 registries = [ "user:token@registry" ]
-ignore = false
 compose = "my\-compose.yaml"
 env = [ "MYVAR=VALUE" ]
 urls = { "example.org" = "pgo:5006" }
@@ -114,9 +113,6 @@ registries:
 containers. Note that different credentials for the same user in different services might lead to
 race conditions (and failed pulls). If the user part is not specifiied, the user from the \fB\fCuser\fR
 keyword is used. This is a list because multiple private repositories are allowed.
-.TP
-ignore
-\fB\fCfalse\fR, ignore changes to the compose yaml files and \fIdo not\fP restart containers.
 .TP
 compose
 \fB\fCmy-compose.yaml\fR, specify an alternate compose file to use, outside of the supported variants.
@@ -166,9 +162,9 @@ Two metrics are exported:
 pgod(8) has following exit codes:
 
 .PP
-0 - normal exit
-1 - error seen (log.Fatal())
-2 - SIGHUP seen (signal to systemd to restart us)
+0 \- normal exit
+1 \- error seen (log.Fatal())
+2 \- SIGHUP seen (signal to systemd to restart us)
 
 .SH "SEE ALSO"
 .PP

--- a/cmd/pgod/pgod.8.md
+++ b/cmd/pgod/pgod.8.md
@@ -29,7 +29,7 @@ there, but you need to make sure your infra also updates externals records (DNS 
 The interface into `pgod` is via SSH, but not OpenSSH, this is a completely seperate SSH interface
 implemented by both `pgod` and `pgoctl`.
 
-For each repository it directs docker compose to pull, build and start the containers defined in the
+For each repository it directs docker compose to pull and start the containers defined in the
 `compose.yaml` file. Whenever this compose file changes this is redone. Current the following
 compose file variants are supported: "compose.yaml", "compose.yml", "docker-compose.yml" and
 "docker-compose.yaml".

--- a/compose/compose.go
+++ b/compose/compose.go
@@ -71,9 +71,6 @@ func (c *Compose) run(args ...string) ([]byte, error) {
 	return out, err
 }
 
-func (c *Compose) Build(args []string) ([]byte, error) {
-	return c.run(append([]string{"build"}, args...)...)
-}
 func (c *Compose) Down(args []string) ([]byte, error) {
 	return c.run(append([]string{"down"}, args...)...)
 }

--- a/conf/conf.go
+++ b/conf/conf.go
@@ -230,10 +230,6 @@ func (s *Service) Track(ctx context.Context, duration time.Duration) {
 		if _, err := s.Compose.Pull(nil); err != nil {
 			log.Warningf("[%s]: Failed pulling containers: %v", s.Name, err)
 		}
-		log.Infof("[%s]: Building images", s.Name)
-		if _, err := s.Compose.Build(nil); err != nil {
-			log.Warningf("[%s]: Failed building containers: %v", s.Name, err)
-		}
 		log.Infof("[%s]: Upping services", s.Name)
 		if _, err := s.Compose.Up(nil); err != nil {
 			log.Warningf("[%s]: Failed upping services: %v", s.Name, err)
@@ -296,10 +292,6 @@ func (s *Service) Track(ctx context.Context, duration time.Duration) {
 		log.Infof("[%s]: Downing services", s.Name)
 		if _, err := s.Compose.Down(nil); err != nil {
 			log.Warningf("[%s]: Failed downing services: %v", s.Name, err)
-		}
-		log.Infof("[%s]: Building images", s.Name)
-		if _, err := s.Compose.Build(nil); err != nil {
-			log.Warningf("[%s]: Failed building containers: %v", s.Name, err)
 		}
 		log.Infof("[%s]: Upping services", s.Name)
 		if _, err := s.Compose.Up(nil); err != nil {


### PR DESCRIPTION
There should never be a need to build on a pgo managed system. Remove
any reference that allows docker-compose build to be run.

Signed-off-by: Miek Gieben <miek@miek.nl>
