### PR TITLE
git: check for transient errors on pull

### DIFF
--- a/conf/conf.go
+++ b/conf/conf.go
@@ -199,6 +199,7 @@ func (s *Service) Track(ctx context.Context, duration time.Duration) {
 
 	if err := s.Git.Checkout(); err != nil {
 		log.Warningf("[%s]: Failed to do (initial) checkout: %v", s.Name, err)
+		// TODO(miek): should prolly _not_ return here, but wait until we succeed
 		return
 	}
 	var errok error

--- a/conf/conf.go
+++ b/conf/conf.go
@@ -197,18 +197,33 @@ func (s *Service) PublicKeys() ([]ssh.PublicKey, error) {
 func (s *Service) Track(ctx context.Context, duration time.Duration) {
 	log.Infof("[%s]: Launched tracking routine for %q", s.Name, s.Name)
 
-	if err := s.Git.Checkout(); err != nil {
-		log.Warningf("[%s]: Failed to do (initial) checkout: %v", s.Name, err)
-		// TODO(miek): should prolly _not_ return here, but wait until we succeed
-		return
+	err := s.Git.Checkout()
+	if err != nil {
+		log.Warningf("[%s]: Failed to do check out, will retry: %v", s.Name, err)
+		for {
+			select {
+			case <-time.After(jitter(duration)):
+				if err := s.Git.Checkout(); err != nil {
+					log.Warningf("[%s]: Failed to do check out, will retry: %v", s.Name, err)
+					continue
+				}
+
+				break
+
+			case <-ctx.Done():
+				return
+			}
+		}
 	}
+	log.Infof("[%s]: Succeeded with check out", s.Name)
+
 	var errok error
 	if _, err := s.Git.Pull(nil); err != nil {
 		log.Warningf("[%s]: Failed to pull: %v", s.Name, err)
 		errok = err
 	}
 	if err := s.Git.Branch(s.Branch); err != nil {
-		log.Warningf("[%s]: Failed to checkout branch %s: %v", s.Name, s.Branch, err)
+		log.Warningf("[%s]: Failed to check out branch %s: %v", s.Name, s.Branch, err)
 		errok = err
 	}
 	pubkeys, err := s.PublicKeys()
@@ -270,7 +285,7 @@ func (s *Service) Track(ctx context.Context, duration time.Duration) {
 				continue
 			}
 			if err := s.Git.Checkout(); err != nil {
-				log.Warningf("[%s]: Failed to do checkout: %v", s.Name, err)
+				log.Warningf("[%s]: Failed to do check out: %v", s.Name, err)
 				continue
 			}
 			changed = true // force action
@@ -334,7 +349,6 @@ func Track(ctx context.Context, file string, done chan<- os.Signal) {
 
 // jitter will add a random amount of jitter [0, d/2] to d.
 func jitter(d time.Duration) time.Duration {
-	rand.Seed(time.Now().UnixNano())
 	max := d / 2
 	return d + time.Duration(rand.Int63n(int64(max)))
 }

--- a/git/git.go
+++ b/git/git.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"strings"
 
 	"github.com/miekg/pgo/metric"
 	"github.com/miekg/pgo/osutil"
@@ -98,6 +99,12 @@ func (g *Git) Pull(names []string) (bool, error) {
 
 	out, err := g.run("pull", "--stat", "--rebase", "origin", g.branch)
 	if err != nil {
+		// if err starts with: 'fatal: unable to access ' and ends with 'Connection refused' we assume a soft
+		// error and return false, nil
+		errmsg := strings.ToLower(err.Error())
+		if strings.HasPrefix(errmsg, "fatal: unable to access") && strings.HasSuffix(errmsg, "connection refused") {
+			return false, nil
+		}
 		return false, err
 	}
 	return g.OfInterest(out, names), nil


### PR DESCRIPTION
if we get 'connection refused', don't assume our git repo is borked.
This is done by checking the error message of git - which is not great.

Better would be to 'git fetch' and 'git merge', but unlike 'git pull'
does cmds don't report what files are changed? (Or do they). Otherwise
we could ignore 'git fetch' errors and only delete the repo on 'git
merge' failures.

Signed-off-by: Miek Gieben <miek@miek.nl>
